### PR TITLE
fix: 修正请求被拦截时内部状态未更新的问题

### DIFF
--- a/src/core/createQuery.ts
+++ b/src/core/createQuery.ts
@@ -89,8 +89,13 @@ const createQuery = <R, P extends unknown[]>(
     const currentCount = count.value;
 
     const { isBreak, breakResult = resolvedPromise() } = emit('onBefore', args);
+
     if (isBreak) {
-      setState({ status: 'settled' });
+      setState({
+        status: 'settled',
+        loading: false,
+        data: breakResult,
+      });
       return breakResult;
     }
 


### PR DESCRIPTION
- 当 isBreak 为 true 时，补充了对 loading 和 data 状态的更新